### PR TITLE
Fixing chemprop version and bump version to 1.0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     },
     install_requires=[
         'chemfunc',
-        'chemprop==1.6.1',
+        'chemprop==1.5.2',
         'descriptastorus',
         'matplotlib',
         'numpy',

--- a/synthemol/_version.py
+++ b/synthemol/_version.py
@@ -1,6 +1,6 @@
 """Contains the version information for synthemol."""
 # major, minor, patch
-version_info = 1, 0, 3
+version_info = 1, 0, 4
 
 # Nice string for the version
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
Fixing setup.py chemprop version for compatibility with trained chemprop models and bumping version to 1.0.4